### PR TITLE
fix bug where we overwrote user token

### DIFF
--- a/assets/scripts/upload/ui.js
+++ b/assets/scripts/upload/ui.js
@@ -32,7 +32,7 @@ const onCreateUploadFailure = function(error) {
 };
 
 const updateUserSuccess = function(data) {
-  app.user = data.user;
+  app.user.uploads = data.user.uploads;
   console.log('in updateUserSuccess, data is:', data);
   console.log('in updateUserSuccess, app.user is:', app.user);
 };


### PR DESCRIPTION
Accidentally removed user token when we updated the user images. Modified function to only update user.uploads instead of the whole user object.
