### PR TITLE
Fix header to display the username of the current 'island'

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -50,6 +50,7 @@ const signOutSuccess = function () {
   $('.navbar').css('margin', '0 auto');
   app.user = null;
   $('.sidebar-nav').html('');
+  $('header h1').html('Desert Island');
 };
 
 const sidebarSuccess = function (data) {

--- a/assets/scripts/templates/display-images.handlebars
+++ b/assets/scripts/templates/display-images.handlebars
@@ -1,7 +1,7 @@
 {{#each uploads}}
 <div class="col-xs-2">
   <div class="thumbnail">
-    <a href = {{this.location}}><img src={{this.location}}></a>
+    <a href = {{this.location}} target="_blank"><img src={{this.location}}></a>
     <div class="caption">
       <h5>{{this.title}}</h5>
       <p>{{this.description}}</p>

--- a/assets/scripts/templates/show-other-user-thumbnails.handlebars
+++ b/assets/scripts/templates/show-other-user-thumbnails.handlebars
@@ -1,7 +1,7 @@
 {{#each uploads}}
 <div class="col-xs-2">
   <div class="thumbnail">
-    <a href = {{this.location}}><img src={{this.location}}></a>
+    <a href = {{this.location}} target="_blank"><img src={{this.location}}></a>
     <div class="caption">
       <h5>{{this.title}}</h5>
       <p>{{this.description}}</p>

--- a/assets/scripts/upload/events.js
+++ b/assets/scripts/upload/events.js
@@ -36,7 +36,6 @@ const onEditUpload = function(event){
   .then((data) => ui.updateUserSuccess(data))
   .then(ui.onUpdateThumbnailSuccess)
   .catch((error) => ui.onError(error));
-
 };
 
 const viewUserIsland = function(event){

--- a/assets/scripts/upload/ui.js
+++ b/assets/scripts/upload/ui.js
@@ -3,6 +3,7 @@
 const app = require('../../scripts/app');
 const displayImageThumbnails = require('../templates/display-images.handlebars');
 const otherUserThumbnailUpdate = require('../templates/show-other-user-thumbnails.handlebars');
+const displayNameHeader = require('../templates/display-name.handlebars');
 
 const onUploadButtonClick = function() {
   $('#upload-button').on('click', function() {
@@ -34,12 +35,14 @@ const onCreateUploadFailure = function(error) {
 
 const updateUserSuccess = function(data) {
   app.user.uploads = data.user.uploads;
+  $('header h1').html(displayNameHeader(app.user));
   console.log('in updateUserSuccess, data is:', data);
   console.log('in updateUserSuccess, app.user is:', app.user);
 };
 
 const updateOtherUserSuccess = function(data) {
   app.otherUser = data.user;
+  $('header h1').html(displayNameHeader(app.otherUser));
   $('#upload-button').hide();
 };
 


### PR DESCRIPTION
When you view another user's 'island', the header now updates
to display their name, as well as displaying your name when viewing
your island. Also made sure header 'resets' when a user signs out.
- Add 'target=_blank' to handlebars thumbnails templates so clicking
  on an image opens it in a new tab.
